### PR TITLE
Fix information about IPL header based on MSC313e disassembly

### DIFF
--- a/blobs/ipl.md
+++ b/blobs/ipl.md
@@ -7,8 +7,10 @@ This is usually copied from memory mapped SPI NOR into the internal SRAM (IMI).
 - First 4 bytes are an ARM instruction to jump somewhere else in the IPL binary like a reset vector.
    This also seems to be generally used to switch from ARM to Thumb execution.
 - Second 4 bytes are "IPL_"
-- Third 4 bytes are the size of the IPL
-- Forth 4 bytes are a checksum of the upcoming data. The checksum is just each u32 of the data added together. The boot rom        doesn't seem to actually check this and not all IPL version check it before loading the second stage IPLC.
+- Next 2 bytes are the size of the IPL
+- Next byte (byte 10) is an optional CID (chip ID?) that will be checked against value stored at address 0x1f00700c, if that value is non-zero (it is zero on MSC313e). If those do not match, an error "CID check failed! [HALT]" will be printed by BootROM and the CPU will go into infinite loop.
+- If next byte (byte 11) has value 0xFA, the authentication of the image will be run. If this authentication fails, "Authenticate failed! [HALT]" will be printed by BootROM and CPU will go into infinite loop. Any other value does not trigger authentication unless bit 0 of the value stored at 0x1f0071c0 is 1.
+- Forth 4 bytes (bytes 12-15) are a checksum of the upcoming data. The checksum is just each u32 of the data added together. The boot rom doesn't seem to actually check this and not all IPL version check it before loading the second stage IPLC.
 
 ### mercury5 notes
 
@@ -18,6 +20,11 @@ This is usually copied from memory mapped SPI NOR into the internal SRAM (IMI).
 ### infinity3 notes
 
 - Located at 0x4000 in SPI NOR.
+
+### authentication notes
+
+In case authentication is performed, a 256 bytes are expected just after normal IPL image. Those bytes are passed through crypto peripheral (0x1f224480 - 0x1f2244af) starting from the last byte till the first one. 256 bytes value seams to be computed out of which 32 last are taken.
+A SHA256 value of the IPL image is calculated by other part of crypto engine (0x1f224400 - 0x1f22445f) and its result is compared with the hash explained above.
 
 #### Version capability/feature matrix
 


### PR DESCRIPTION
This information is taken from the msc313ebootroom.bin after
disassembling what seems to be a main() function that starts at offset
0x29e. Most of the code performing those checks is between 0x41a and
0x43c.